### PR TITLE
Small fix to follow links; mapping for <C-O>

### DIFF
--- a/plugin/info.vim
+++ b/plugin/info.vim
@@ -36,7 +36,7 @@ endif
 let s:dirPattern = '^\* [^:]*: \(([^)]*)\)'
 let s:menuPattern = '^\* \([^:]*\)::'
 let s:notePattern = '\*[Nn]ote\%(\s\|$\)'
-let s:indexPattern = '^\* [^:]*:\s*\([^.]*\)\.$'
+let s:indexPattern = '^\* [^:]*:\s*\([^.]*\)\.'
 let s:indexPatternHL = '^\* [^:]*:\s\+[^(]'
 
 command! -nargs=* -complete=shellcmd Info call s:Info(<f-args>)
@@ -162,6 +162,7 @@ fun! s:InfoBufferInit()
 "    noremap <buffer> l		:call <SID>LastNode()<cr>
     noremap <buffer> ;		:call <SID>LastNode()<cr>
     noremap <buffer> <C-T>	:call <SID>LastNode()<cr>
+    noremap <buffer> <C-O> 	:call <SID>LastNode()<cr>
     noremap <buffer> <C-S>	/
     " FIXME: <n> is go to next match
 "    noremap <buffer> n		:call <SID>NextNode()<cr>
@@ -190,7 +191,7 @@ fun! s:Help()
     echo '<Backspace>	Scroll backward (page up).'
     echo '<Tab>		Move cursor to next hyperlink within this node.'
     echo '<Enter>,<C-]>	Follow hyperlink under cursor.'
-    echo ';,<C-T>		Return to last seen node.'
+    echo ';,<C-T>,<C-O>	Return to last seen node.'
     echo '.,>		Move to the "next" node of this node.'
     echo 'p,<		Move to the "previous" node of this node.'
     echo 'u		Move "up" from this node.'


### PR DESCRIPTION
The small change in the s:indexPattern is necessary to follow some links, such
as the first two links in menu in :Info info -> Getting Started -> Help-M::

```
  * Menu:

  * Foo:  Help-FOO.       A node you can visit for fun.
  * Bar:  Help-FOO.       We have made two ways to get to the same place.
  * Help-FOO::            And yet another!
```

The mapping for Ctrl-O is useful because its default behavior breaks the
plugin by leaving the special buffer.
